### PR TITLE
Retrieve search URL from breadcrumbs

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -39,18 +39,13 @@ function getListingDetails() {
     if (listingDetails.type === 'tm') {
 
         listingDetails.title = encodeURIComponent($('.tm-property-listing-body__title')?.text()?.trim()?.toLowerCase());
-        const location = $('.tm-property-listing-body__location').text().trim().split(',');
-        listingDetails.region = location[location.length - 1].trim().toLowerCase().replace(/ /g, '-');
-        listingDetails.district = location[location.length - 2].trim().toLowerCase().replace(/ /g, '-');
-        listingDetails.suburb = location[location.length - 3].trim().toLowerCase().replace(/ /g, '-');
+        listingDetails.baseUrl = $('.tm-breadcrumbs').find('.o-breadcrumbs__item').last().find('a').attr('href');
         listingDetails['anchor'] = '.tm-property-listing-body__price';
 
     } else {
 
         listingDetails.title = encodeURIComponent($('div[data-test="listing-subtitle"]')?.text()?.trim()?.toLowerCase());
-        listingDetails.region = $('a[data-test="breadcrumbs__region"]').text().trim().toLowerCase().replace(/ /g, '-');
-        listingDetails.district = $('a[data-test="breadcrumbs__district"]').text().trim().toLowerCase().replace(/ /g, '-');
-        listingDetails.suburb = $('a[data-test="breadcrumbs__suburb"]').text().trim().toLowerCase().replace(/ /g, '-');
+        listingDetails.baseUrl = $('a[data-test="breadcrumbs__suburb"]').attr('href');
         listingDetails['anchor'] = 'div[data-test="page-section"]';
 
     }
@@ -228,12 +223,16 @@ async function checkListingPrice(listingDetails, min, max) {
     let url;
 
     if (listingDetails.type === 're') {
-
-        url = `https://www.realestate.co.nz/${listingDetails.propertyCategory}/sale/${listingDetails.region}/${listingDetails.district}/${listingDetails.suburb}?k="${listingDetails.title}"&minp=${min}&maxp=${max}`;
+        
+        url = `https://www.realestate.co.nz${listingDetails.baseUrl}?k="${listingDetails.title}"`;
+        if (min > 0) {
+            url += `&minp=${min}`;
+        }
+        url += `&maxp=${max}`;
 
     } else {
 
-        url = `https://www.trademe.co.nz/a/property/residential/sale/${listingDetails.region}/${listingDetails.district}/${listingDetails.suburb}/search?price_min=${min}&price_max=${max}&search_string=${listingDetails.title}`;
+        url = `https://www.trademe.co.nz/a/${listingDetails.baseUrl}/search?price_min=${min}&price_max=${max}&search_string=${listingDetails.title}`;
 
     }
 
@@ -307,12 +306,40 @@ async function getListingPrice(listingDetails, min, max) {
 
         } else {
 
+            $("#cheeky-progress").remove();
+            $("#cheeky-price").remove();
+            $("#cheeky-loader").remove();
+
+            $('#cheeky-avo').prepend(`
+                <img id="cheeky-logo-loaded" src="data:image/png;base64, ${logo}"/>
+            `);
+
+            $('#cheeky-content').append(`
+                <span id="cheeky-error">
+                    Error processing this listing
+                </span>
+            `);
+
             console.error('No Results Found');
             throw new Error('No Results Found');
 
         }
 
     } catch (error) {
+
+        $("#cheeky-progress").remove();
+        $("#cheeky-price").remove();
+        $("#cheeky-loader").remove();
+
+        $('#cheeky-avo').prepend(`
+            <img id="cheeky-logo-loaded" src="data:image/png;base64, ${logo}"/>
+        `);
+
+        $('#cheeky-content').append(`
+            <span id="cheeky-error">
+                Error processing this listing
+            </span>
+        `);
 
         console.error(error);
         throw new Error('No Results Found');


### PR DESCRIPTION
Get search URLs from the last breadcrumb, which is the most reliable way to retrieve the search URL, as we don't have to format anything ourselves.
Cases I discovered where manually constructing the URL was falling over:
* Single quote in a region/district/suburb, e.g. Hawke's Bay (TradeMe omits these)
* There was no suburb on the listing, the street address was being used in this case, [as seen here](https://www.trademe.co.nz/a/property/residential/sale/bay-of-plenty/whakatane/whakatane/listing/3478725770)

Also tell the user if any error is hit, so they're not left wondering if it's still running.